### PR TITLE
Add testing capability with multiple versions of home-assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.req
 *.csr
 *.cnf
-*.conf
 *.backup
+test/config-homeassistant
 ha-version.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+SHELL=/bin/bash
+TEST_DIR:=test
+TEST_ENV:=stable
+TEST_SITE:=haci-test-nginx
+SUBJ:='/C=HU/ST=Budapest/O=HACItest/CN=haci-test-nginx'
+COMPOSE_CMD=docker compose -f ${TEST_DIR}/docker-compose/docker-compose.yaml -f ${TEST_DIR}/docker-compose/docker-compose-env.yaml
+export
+
+.PHONY: all
+all:
+	@echo -ne "Usage: \t make run-tests: \t\tthis will launch default stable env\n\t make TEST_ENV=dev run-tests: \tthis will test against homassistant:dev\n"
+	@echo -ne "\nTEST_ENV options are: \tstable, dev, beta, rc, latest\nFull list of options at: https://hub.docker.com/r/homeassistant/home-assistant/tags\n"
+	@exit 0
+
+.PHONY: run-tests
+run-tests: clean
+run-tests: start-test-env
+run-tests: add-haci-config
+run-tests: test-haci
+run-tests: stop-test-env
+run-tests: clean
+
+.PHONY: start-test-env
+start-test-env:
+	@echo -ne " * Building home-assistant (${TEST_ENV})... "
+	@mkdir -p ${TEST_DIR}/cert-gen
+	@export COMPOSE_DOCKER_CLI_BUILD=0 && export TEST_ENV=${TEST_ENV} && \
+		${COMPOSE_CMD} up --force-recreate --remove-orphans --detach || { \
+				echo -ne "\n\n!!!\n!!! DOCKER-COMPOSE LOG\n!!!\n"; ${COMPOSE_CMD} logs | grep --color=always -i "(error\|err\|warn\|warning)"; \
+				${COMPOSE_CMD} rm -v; echo ❌; exit 1; }
+
+
+.PHONY: add-haci-config
+add-haci-config:
+	@echo -ne " * Adding HACI config... "
+	@echo -ne 'test_site="https://${TEST_SITE}"\ncertifi=yes\n' > haci.conf && echo ✅ || echo ❌
+
+.PHONY: test-haci
+test-haci:
+	${COMPOSE_CMD} logs
+	@echo -ne " * Waiting for HASS to come alive... "
+	@until curl --retry 5 --retry-all-errors --connect-timeout 1 -s http://localhost:8823/ -o /dev/null; do sleep 1; done && echo ✅ || echo ❌
+	@echo -ne " * Testing HACI"
+	@docker exec homeassistant-${TEST_ENV} /haci/haci.sh debug && echo "✅ PASSED" || { echo "❌ FAILED."; exit 1; }
+
+.PHONY: stop-test-env
+stop-test-env:
+	@echo -ne " * Stopping test environment... "
+	@${COMPOSE_CMD} down -v >/dev/null && echo ✅ || echo ❌
+
+.PHONY: clean
+clean:
+	@echo -ne " * Cleaning temp data... "
+	@rm -rf ${TEST_DIR}/cert-gen/* ${TEST_DIR}/config-nginx/certs/* haci.conf ca-certificates.crt.backup cacert.pem.backup > /dev/null 2>&1 || exit 0
+	@echo ✅
+

--- a/test/config-nginx/html/index.html
+++ b/test/config-nginx/html/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<title>HACI Test Site</title>
+</head>
+<body>
+<div>It werk, it werk!</div>
+</body>
+</html>

--- a/test/config-nginx/nginx.conf
+++ b/test/config-nginx/nginx.conf
@@ -1,0 +1,28 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen 80;
+    listen 443 ssl;
+    server_name haci-test-nginx;
+    ssl_certificate /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    location / {
+      root /usr/share/nginx/html;
+      index index.html;
+    }
+  }
+}
+
+
+
+
+
+
+
+

--- a/test/config-openssl/intermediate.ext
+++ b/test/config-openssl/intermediate.ext
@@ -1,0 +1,3 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:TRUE
+keyUsage=critical, cRLSign, digitalSignature, keyCertSign

--- a/test/config-openssl/server.ext
+++ b/test/config-openssl/server.ext
@@ -1,0 +1,8 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage=critical, digitalSignature, keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=@alt_names
+
+[alt_names]
+DNS.1=haci-test-nginx

--- a/test/docker-compose/docker-compose-env.yaml
+++ b/test/docker-compose/docker-compose-env.yaml
@@ -1,0 +1,5 @@
+version: '3.9'
+services:
+  homeassistant:
+    container_name: homeassistant-${TEST_ENV}
+    image: "homeassistant/home-assistant:${TEST_ENV}"

--- a/test/docker-compose/docker-compose.yaml
+++ b/test/docker-compose/docker-compose.yaml
@@ -1,0 +1,65 @@
+version: '3.9'
+services:
+  # create rootca, intermediateca, and server certs
+  certs:
+    image: alpine:latest
+    container_name: haci-certs
+    command: >
+      sh -c  "apk add openssl && \
+
+              openssl genrsa -out /certs/root.key 2048 && \
+              openssl req -x509 -new -nodes -key /certs/root.key -sha256 -days 1 -subj '${SUBJ}' -out /certs/root.crt && \
+
+              openssl genrsa -out /certs/intermediate.key 2048 && \
+              openssl req -new -key /certs/intermediate.key -subj '${SUBJ}' -out /certs/intermediate.csr && \
+              openssl x509 -req -in /certs/intermediate.csr -CA /certs/root.crt -CAkey /certs/root.key -CAcreateserial -sha256 -days 1 -extfile /config/intermediate.ext -out /certs/intermediate.crt && \
+
+              openssl genrsa -out /nginx/server.key 2048 && \
+              openssl req -new -key /nginx/server.key -subj '${SUBJ}' -out /certs/server.csr && \
+              openssl x509 -req -in /certs/server.csr -CA /certs/intermediate.crt -CAkey /certs/intermediate.key -CAcreateserial -sha256 -days 1 -extfile /config/server.ext -out /certs/server.crt && \
+
+              cat /certs/server.crt /certs/intermediate.crt > /nginx/server.crt && \
+              rm /certs/*.csr /certs/*.srl /certs/*.key certs/server.crt && \
+
+              while true; do sleep 6635; done"
+    volumes:
+      - ../cert-gen:/certs
+      - ../config-nginx/certs:/nginx
+      - ../config-openssl:/config
+    healthcheck:
+      test: ["CMD", "ls", "-1", "/nginx/server.crt"]
+      interval: 5s
+      timeout: 2s
+      retries: 50
+      start_period: 10s
+
+  # nginx config to host a site to test with
+  haci-test-nginx:
+    container_name: ${TEST_SITE}
+    image: nginx
+    ports:
+      - "8443:443"
+      - "8080:80"
+    volumes:
+      - ../config-nginx:/etc/nginx
+      - ../config-nginx/html:/usr/share/nginx/html
+    depends_on:
+      certs:
+        condition: service_healthy
+
+  # homeassistant (please note the docker-compose-env override for dev/beta/stable builds)
+  homeassistant:
+    # env override fills in image - see docker-compose-env.yaml
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ../../:/haci
+      - ../cert-gen:/haci/certs
+    ports:
+      - "8823:8123"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8123"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - haci-test-nginx


### PR DESCRIPTION
This PR adds testing capability against multiple versions of home-assistant.
Components:

- Docker compose
  - Home Assistant : Version: defaults to `stable`, but can be overridden with any [home_assistant:tag](https://hub.docker.com/r/homeassistant/home-assistant) dockerhub outlines.
  - Certificates: OpenSSL generates Root CA, Intermediate CA, a server.key and .crt that, and builds a chained cert for nginx to pick up.
  - Nginx, nginx config and test html: creates a legit https://host with the certs generated, for HACI to test against.

To leverage this, run: `make run-tests`
To override the environment, run: `make TEST_ENV=dev run-tests` (or rc, beta, etc).

This is candidate to be connected into github CI, so we can keep track of how HACI is behaving against various HASS versions already known and/or in the pipeline.