### PR TITLE
Add gitbhub ci

### DIFF
--- a/.github/workflows/hass-dev-haci-test.yml
+++ b/.github/workflows/hass-dev-haci-test.yml
@@ -1,0 +1,17 @@
+name: HACI on HASS dev
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  hass-dev-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=dev run-tests

--- a/.github/workflows/hass-dev-haci-test.yml
+++ b/.github/workflows/hass-dev-haci-test.yml
@@ -2,9 +2,9 @@ name: HACI on HASS dev
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/hass-latest-haci-test.yml
+++ b/.github/workflows/hass-latest-haci-test.yml
@@ -1,0 +1,17 @@
+name: HACI on HASS latest
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  hass-latest-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=latest run-tests

--- a/.github/workflows/hass-latest-haci-test.yml
+++ b/.github/workflows/hass-latest-haci-test.yml
@@ -2,9 +2,9 @@ name: HACI on HASS latest
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/hass-rc-haci-test.yaml
+++ b/.github/workflows/hass-rc-haci-test.yaml
@@ -1,0 +1,17 @@
+name: HACI on HASS rc
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  hass-rc-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=rc run-tests

--- a/.github/workflows/hass-rc-haci-test.yaml
+++ b/.github/workflows/hass-rc-haci-test.yaml
@@ -2,9 +2,9 @@ name: HACI on HASS rc
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/hass-reference-haci-test.yml
+++ b/.github/workflows/hass-reference-haci-test.yml
@@ -2,9 +2,9 @@ name: HACI on HASS 2023.4 Reference
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/hass-reference-haci-test.yml
+++ b/.github/workflows/hass-reference-haci-test.yml
@@ -1,0 +1,17 @@
+name: HACI on HASS 2023.4 Reference
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  hass-reference-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=2023.4 run-tests

--- a/.github/workflows/hass-stable-haci-test.yml
+++ b/.github/workflows/hass-stable-haci-test.yml
@@ -2,9 +2,9 @@ name: HACI on HASS stable
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/hass-stable-haci-test.yml
+++ b/.github/workflows/hass-stable-haci-test.yml
@@ -1,0 +1,17 @@
+name: HACI on HASS stable
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  hass-stable-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=stable run-tests


### PR DESCRIPTION
This PR Configures Github Actions with the following jobs:

- HACI vs Home Assistant DEV
- HACI vs Home Assistant LATEST
- HACI vs Home Assistant RC
- HACI vs Home Assistant STABLE
- HACI vs Home Assistant Reference (2023.4 known good version)

CI runs on PR & Merge and every night