### PR TITLE
Change ssl verification logic from curl to openssl

### DIFF
--- a/.github/workflows/hass-latest-haci-legacy-config-202305
+++ b/.github/workflows/hass-latest-haci-legacy-config-202305
@@ -1,0 +1,15 @@
+name: HACI on HASS latest
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  hass-latest-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build env and run tests
+      run: make TEST_ENV=latest CONFIG_VERSION=202305

--- a/.github/workflows/hass-latest-haci-legacy-config-202305
+++ b/.github/workflows/hass-latest-haci-legacy-config-202305
@@ -1,4 +1,4 @@
-name: HACI on HASS latest
+name: HACI on HASS latest with Legacy Config 202305
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ TEST_ENV:=stable
 TEST_SITE:=haci-test-nginx
 SUBJ:='/C=HU/ST=Budapest/O=HACItest/CN=haci-test-nginx'
 COMPOSE_CMD=docker compose -f ${TEST_DIR}/docker-compose/docker-compose.yaml -f ${TEST_DIR}/docker-compose/docker-compose-env.yaml
+
+include legacy.mk
+
 export
 
 .PHONY: all
@@ -29,12 +32,12 @@ start-test-env:
 				echo -ne "\n\n!!!\n!!! DOCKER-COMPOSE LOG\n!!!\n"; ${COMPOSE_CMD} logs | grep --color=always -i "(error\|err\|warn\|warning)"; \
 				${COMPOSE_CMD} rm -v; echo ❌; exit 1; }
 
-
 .PHONY: add-haci-config
 add-haci-config:
-	@echo -ne " * Adding HACI config... "
-	@echo -ne 'test_site="https://${TEST_SITE}"\ncertifi=yes\n' > haci.conf && echo ✅ || echo ❌
+	@echo -ne " * Adding HACI config: ${TEST_SITE_STRING}... "
+	@echo -ne 'test_site="${TEST_SITE_STRING}"\ncertifi=yes\n' > haci.conf && echo ✅ || echo ❌
 
+# haci test
 .PHONY: test-haci
 test-haci:
 	${COMPOSE_CMD} logs

--- a/haci.conf.sample
+++ b/haci.conf.sample
@@ -5,8 +5,9 @@
 ### test_site
 ### A https website that is signed by your self-signed certificate.
 ### This is to confirm that certificate injection is required and that it was successful.
+### Accepts ip:hostname format (please note that https://site:port format is deprecated)
 ###
-# test_site="https://my-ttrss.lan"
+# test_site="my-ttrss.lan"
 
 ### certifi
 ### Set to any value to add certs to python certifi.

--- a/haci.sh
+++ b/haci.sh
@@ -42,7 +42,11 @@ function FIND_BIN {
 }
 
 # validate internal ssl test site
-function CHECK_SSL_INT { a=`echo | openssl s_client -connect "$test_site" -servername "${test_site%%:*}" 2>/dev/null` || return 1; }
+function CHECK_SSL_INT {
+    a=`echo | openssl s_client -connect "$test_site" -servername "${test_site%%:*}" 2>/dev/null`
+    if [[ $a =~ "self-signed certificate in certificate chain" ]]; then return 1; fi
+    return 0
+}
 function CHECK_SSL_INT_INSECURE { a=`$curl -m 2 -sk "$test_site"` && return 0 || return 1; }
 function CHECK_SSL_INT_PY { a=`$python ${0%/*}/haci_ssl_test.py "$test_site"` || return 1; }
 

--- a/haci_ssl_test.py
+++ b/haci_ssl_test.py
@@ -1,0 +1,13 @@
+import sys
+import requests
+
+host_port = sys.argv[1]
+host, port = host_port.split(':')
+
+try:
+    requests.get(f"https://{host}:{port}", timeout = 1)
+    exit(0)  # Certificate is valid
+except requests.exceptions.SSLError:
+    exit(1)  # Certificate is invalid
+except requests.exceptions.RequestException:
+    exit(1)  # Other connection error

--- a/legacy.mk
+++ b/legacy.mk
@@ -1,0 +1,8 @@
+# Legacy tests
+
+# handle legacy config test
+CONFIG_VERSION:=latest
+TEST_SITE_STRING=${TEST_SITE}
+ifeq ($(CONFIG_VERSION),202305)
+	TEST_SITE_STRING=https://${TEST_SITE}
+endif

--- a/test/config-nginx/htpasswd
+++ b/test/config-nginx/htpasswd
@@ -1,0 +1,1 @@
+username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=

--- a/test/config-nginx/nginx.conf
+++ b/test/config-nginx/nginx.conf
@@ -13,16 +13,18 @@ http {
     ssl_certificate_key /etc/nginx/certs/server.key;
 
     location / {
+      # Auth header test
+      if ($http_x_auth = "") {
+        return 403;
+      }
+
+      # Simple HTTP Basic Auth test (username:password)
+      auth_basic "Restricted Access";
+      auth_basic_user_file /etc/nginx/htpasswd;
+
+      # standard location config
       root /usr/share/nginx/html;
       index index.html;
     }
   }
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR is aimed at fixing a problem with testing SSL sites behind authentication as discussed in #15 
The proposal replaces `curl` with `openssl` when it comes to validation, expecting that to take place before any authentication request user faces.

The nginx server for testing now has simple http auth and auth header requirements too, passing these will need: `curl --user username:password -H "X-Auth: token" https://haci-test-nginx -svk` (this is literal, username is really username for this test).

TODO: add ssl client cert auth to nginx, should that ever come up as a problem :)